### PR TITLE
Fix: typo in sound.cfg documentation

### DIFF
--- a/content/en/trains/sound_cfg/_index.md
+++ b/content/en/trains/sound_cfg/_index.md
@@ -206,7 +206,7 @@ Played in a continuous loop whilst the music horn is active.
 
 ------
 
-##### ● [Horn]
+##### ● [Door]
 
 {{% command %}}  
 Open Left = *FileName*  


### PR DESCRIPTION
https://bveworldwide.forumotion.com/t1861-incorrect-sound-cfg-documentation