### PR TITLE
Fix typo on documentations

### DIFF
--- a/content/en/information/distribution/_index.md
+++ b/content/en/information/distribution/_index.md
@@ -53,7 +53,7 @@ Acceptable and not acceptable practices:
 
 ## ■ Archives and the folder structure
 
-You should always include the full folder structure, that is, **Railway** and **Train**, when istributing outes or trains. This will make it easiest for people to understand where they need to extract the ontent to. Never just include a subdirectory such as *YourNameHere* that is supposed to be extracted to the Railway\Sound folder, for example. Only the more experienced users will enerally e able to figure out where to put such content to by examining the files or their extensions.
+You should always include the full folder structure, that is, **Railway** and **Train**, when distributing routes or trains. This will make it easiest for people to understand where they need to extract the content to. Never just include a subdirectory such as *YourNameHere* that is supposed to be extracted to the Railway\Sound folder, for example. Only the more experienced users will generally be able to figure out where to put such content to by examining the files or their extensions.
 
 Acceptable and not acceptable practices:
 
@@ -67,7 +67,7 @@ Acceptable and not acceptable practices:
 
 ## ■ Errors and warnings
 
-Generally, your route should be free of errors. Please note that openBVE distinguishes between errors and warnings. An error is something definately wrong with your coding that should be fixed immediately. A warning is usually only raised to encourage inspection of potentially ambiguous code or code that might not have been meant the way it was written. In order to inspect your routes and trains for errors and warnings, go to the Options menu in openBVE and enable eporting them. RouteViewer and ObjectViewer always report such messages. Please note that the arious tools and openBVE itself might report a different set of messages as they don't share all the ame functionality. Distributing add-ons containing errors might give users the impression that omething was incompletely downloaded or was incorrectly packaged, and should generally be voided.
+Generally, your route should be free of errors. Please note that openBVE distinguishes between errors and warnings. An error is something definately wrong with your coding that should be fixed immediately. A warning is usually only raised to encourage inspection of potentially ambiguous code or code that might not have been meant the way it was written. In order to inspect your routes and trains for errors and warnings, go to the Options menu in openBVE and enable reporting them. RouteViewer and ObjectViewer always report such messages. Please note that the arious tools and openBVE itself might report a different set of messages as they don't share all the same functionality. Distributing add-ons containing errors might give users the impression that something was incompletely downloaded or was incorrectly packaged, and should generally be voided.
 
 Acceptable and not acceptable practices:
 

--- a/content/en/objects/native/csv/_index.md
+++ b/content/en/objects/native/csv/_index.md
@@ -25,6 +25,7 @@ weight: 2
   - [SetColor](#setcolor)
   - [SetEmissiveColor](#setemissivecolor)
   - [SetBlendMode](#setblendmode)
+  - [SetWrapMode](#setwrapmode)
   - [LoadTexture](#loadtexture)
   - [SetDecalTransparentColor](#setdecaltransparentcolor)
   - [SetCoordinates](#settexturecoordinates)
@@ -331,13 +332,26 @@ This command sets the emissive color for all faces that were already created in 
 
 This command sets the blend mode for all faces in the current CreateMeshBuilder section. The *Normal* mode replaces screen pixels with texture pixels. The *Additive* mode adds the color of texture pixels to the color of screen pixels, where adding black does not change the screen pixel, while adding white results in white. If *GlowHalfDistance* is 0, glow attenuation will be disabled, which is the default. If glow attenuation is to be used, *GlowHalfDistance* represents the distance in meters at which the glow is exactly at 50% of its intensity. When the camera approaches the face, the face will gradually fade out (become transparent). The function used to determine the exact intensity for a given distance can be influenced with the setting of *GlowAttenuationMode*. DivideExponent2 creates a smoother transition, but will converge to the maximum intensity very slowly, while DivideExponent4 creates a sharper transition which converges more quickly.
 
-{{% warning %}}
+------
 
-#### openBVE 2 compatibility note
+<a name="setwrapmode"></a>
 
-In openBVE 2, only additive glow will be supported and the *GlowAttenuationMode* parameter is likely going to be dropped. Please avoid using normal blending in conjunction with using glow.
+{{% command %}}  
+**SetWrapMode**, *WrapMode*
+{{% /command %}}
 
-{{% /warning %}}
+{{% command-arguments %}}  
+***WrapMode***: The openGL texture wrapping mode to use. If this is not specified, the game will attempt to auto-determine the most appropriate texture wrapping mde.  
+{{% /command-arguments %}}
+
+▸ Available options for *WrapMode*:
+
+{{% command-arguments %}}  
+**ClampClamp**: The texture is clamped to edge on both axes. 
+**ClampRepeat**: The texture is clamped to edge on the x-axis and repeats on the y-axis. 
+**RepeatClamp**: The texture repeats on the x-axis and is clamped to edge on the y-axis.
+**RepeatRepeat**: The texture repeats on both axes.
+{{% /command-arguments %}}
 
 ------
 

--- a/content/en/routes/csv/_index.md
+++ b/content/en/routes/csv/_index.md
@@ -646,7 +646,7 @@ Route.RunInterval is the same as Train.Interval.
 {{% /command %}}
 
 {{% command-arguments %}}  
-***Value***: A floating-point number representing the initial temperature in **Celsius**. The default value is 20.  
+***ValueInCelsius***: A floating-point number representing the initial temperature in **Celsius**. The default value is 20.  
 {{% /command-arguments %}}
 
 ---
@@ -840,7 +840,7 @@ The train developer provides a repertoire of different run sounds. Use this comm
 
 {{% command-arguments %}}  
 ***RailTypeIndex***: A non-negative integer representing the rail type as defined via Structure.Rail and used via Track.RailType.  
-***RunSoundIndex***: A non-negative integer representing the train's flange sound to associate to the rail type.  
+***FlangeSoundIndex***: A non-negative integer representing the train's flange sound to associate to the rail type.  
 {{% /command-arguments %}}
 
 The train developer provides a repertoire of different flange sounds. Use this command to associate these flange sounds to the rail types you use in your route. In order for the correct flange sounds to be played on any of your rail types, you need to coordinate your efforts with the train developer. Please see the page about [standards]({{< ref "/information/standards/_index.md" >}}) for further information.
@@ -894,12 +894,12 @@ Train.Gauge is the same as Route.Gauge.
 {{% /command %}}
 
 {{% command-arguments %}}  
-***ValueInSeconds***: A floating-point number representing the time interval between the player's train and the preceding train, measured in **seconds**. The default value is 0.  
+***Interval<sub>i</sub>***: A floating-point number representing the time interval between the player's train and the preceding train, measured in **seconds**. The default value is 0.  
 {{% /command-arguments %}}
 
 {{% note %}}
 
-Train.ValueInSeconds is the same as Route.RunInterval.
+Train.Interval is the same as Route.RunInterval.
 
 {{% /note %}}
 
@@ -1328,7 +1328,7 @@ This command sets the adhesion of the track from this point on. As a reference, 
 {{% /command %}}
 
 {{% command-arguments %}}  
-***Rate***: A non-negative floating-point number measured in percent representing the intensity of the current rainfall. The default value is 0.  
+***Intensity***: A non-negative floating-point number measured in percent representing the intensity of the current rainfall. The default value is 0.  
 ***WeatherType***: A non-negative integer referencing the weather type to use as defined by Structure.Weather from this point onwards.
 {{% /command-arguments %}}
 
@@ -1347,7 +1347,7 @@ It is also possible to set the rain intensity using the legacy BVE4 beacon based
 {{% /command %}}
 
 {{% command-arguments %}}  
-***Rate***: A non-negative floating-point number measured in percent representing the intensity of the current snowfall. The default value is 0.  
+***Intensity***: A non-negative floating-point number measured in percent representing the intensity of the current snowfall. The default value is 0.  
 ***WeatherType***: A non-negative integer referencing the weather type to use as defined by Structure.Weather from this point onwards.
 {{% /command-arguments %}}
 
@@ -1416,7 +1416,7 @@ This command can only be used at the beginning of a block.
 {{% /command %}}
 
 {{% command-arguments %}}  
-***Rate***: A floating-point number representing a turn. The default value is 0.  
+***Ratio***: A floating-point number representing a turn. The default value is 0.  
 {{% /command-arguments %}}
 
 This command creates a point-based turn at the point of insertion. *Ratio* indicates the ratio between the length difference *Z* and the horizontal offset *X* in the following way:


### PR DESCRIPTION
This PR fixes missing characters on the Distribution page & wrong parameter name on the command argument description in CSV route documentations